### PR TITLE
Fix segfault when boot data is zero in SDP

### DIFF
--- a/libuuu/sdp.cpp
+++ b/libuuu/sdp.cpp
@@ -415,8 +415,11 @@ int SDPWriteCmd::run(CmdCtx*ctx)
 			IvtHeader *pIvt = search_ivt_header(fbuff, off, 0x100000);
 			if (pIvt)
 			{
-				BootData *pDB = (BootData *) &(fbuff->at(off + pIvt->BootData - pIvt->SelfAddr));
-				offset = off + pDB->ImageSize - (pIvt->SelfAddr - pDB->ImageStartAddr);
+				if (pIvt->BootData)
+				{
+					BootData *pDB = (BootData *) &(fbuff->at(off + pIvt->BootData - pIvt->SelfAddr));
+					offset = off + pDB->ImageSize - (pIvt->SelfAddr - pDB->ImageStartAddr);
+				}
 			}
 			else
 			{


### PR DESCRIPTION
When writing a U-Boot image with type of firmware_ivt, because the boot data is zero, uuu will crash with segfault when running the following command:

    SDPV: write -f _image0 -skipspl -offset 0x11000

This commit fixes this segfault crash.