### PR TITLE
Fix issues if file size isn't divisible by block size in fastboot

### DIFF
--- a/libuuu/fastboot.cpp
+++ b/libuuu/fastboot.cpp
@@ -1035,6 +1035,7 @@ int FBLoop::run(CmdCtx* ctx)
 	int ret = 0;
 	string_ex err;
 	size_t offset = 0;
+	size_t seek = 0;
 	FastBoot fb(&dev);
 	string_ex cmd;
 	shared_ptr<FileBuffer> p1 = get_file_buffer(m_filename, true);
@@ -1053,11 +1054,13 @@ int FBLoop::run(CmdCtx* ctx)
 	call_notify(nt);
 
 	offset = m_skip;
+	seek = m_seek;
 
 	while((fbuff = p1->request_data(offset, m_each)))
 	{
-		ret = this->each(fb, fbuff, offset);
+		ret = this->each(fb, fbuff, seek);
 		offset += fbuff->size();
+		seek += fbuff->size();
 
 		if (!m_nostop && ret)
 			return ret;
@@ -1098,7 +1101,7 @@ int FBCRC::each(FastBoot& fb, std::shared_ptr<DataBuffer> fbuff, size_t off)
 {
 	uint32_t crc = crc32(0, fbuff->data(), fbuff->size());
 
-	string cmd = build_cmd(m_uboot_cmd, (off + m_seek) / m_blksize, fbuff->size() / m_blksize);
+	string cmd = build_cmd(m_uboot_cmd, off / m_blksize, fbuff->size() / m_blksize);
 
 	if (fb.Transport(cmd, nullptr, 0))
 		return -1;

--- a/libuuu/fastboot.cpp
+++ b/libuuu/fastboot.cpp
@@ -1101,7 +1101,7 @@ int FBCRC::each(FastBoot& fb, std::shared_ptr<DataBuffer> fbuff, size_t off)
 {
 	uint32_t crc = crc32(0, fbuff->data(), fbuff->size());
 
-	string cmd = build_cmd(m_uboot_cmd, off / m_blksize, fbuff->size() / m_blksize);
+	string cmd = build_cmd(m_uboot_cmd, off / m_blksize, div_round_up(fbuff->size(), m_blksize));
 
 	if (fb.Transport(cmd, nullptr, 0))
 		return -1;
@@ -1127,7 +1127,7 @@ int FBWrite::each(FastBoot& fb, std::shared_ptr<DataBuffer> fbuff, size_t off)
 	if (fb.Transport(cmd, fbuff->data(), fbuff->size()))
 		return -1;
 
-	string cmd_w = build_cmd(m_uboot_cmd, off/m_blksize, fbuff->size()/m_blksize);
+	string cmd_w = build_cmd(m_uboot_cmd, off / m_blksize, div_round_up(fbuff->size(), m_blksize));
 	if (fb.Transport(cmd_w, nullptr, 0))
 		return -1;
 

--- a/libuuu/libcomm.h
+++ b/libuuu/libcomm.h
@@ -152,6 +152,12 @@ inline T round_up(T x, T align)
 	return (x + align - 1) / align * align;
 }
 
+template <class T>
+inline T div_round_up(T x, T align)
+{
+	return (x + align - 1) / align;
+}
+
 inline std::string trim(const std::string &s)
 {
 	auto  wsfront = std::find_if_not(s.begin(), s.end(), [](int c) {return std::isspace(c); });

--- a/uuu/uuu.lst
+++ b/uuu/uuu.lst
@@ -34,11 +34,18 @@ uuu_version 1.0.0
 #                      acmd <any never returned uboot command, like booti, reboot>
 #                      flash [-raw2sparse] <partition> <filename>
 #                      download -f <filename>
-#                      crc -f <filename> [-format "mmc read $loadaddr"] [-blksz 512][ -crcblock 0x4000000]
+#                      crc -f <filename> [-format "mmc read $loadaddr"] [-blksz 512] [-each 0x4000000]
 #                                        [-seek 0] [-skip 0] [-nostop]
-#                                          seek          skip block number from storage
-#                                          skip          skips byte from -f
+#                                          each          CRC size each loop
+#                                          seek          skip bytes from storage
+#                                          skip          skip bytes from -f
 #                                          nostop        continue check even if found mismatch
+#                      write -f <filename> [-format "mmc write $loadaddr"] [-blksz 512] [-each 0x4000000]
+#                                        [-seek 0] [-skip 0] [-nostop]
+#                                          each          write size each loop
+#                                          seek          skip bytes from storage
+#                                          skip          skip bytes from -f
+#                                          nostop        continue write even if error occurs
 #
 #
 #          FBK: community with kernel with fastboot protocol. DO NOT compatible with fastboot tools.


### PR DESCRIPTION
When the file size isn't divisible by block size, the block number needs to round up to next block.

Also fix seeking and skipping offsets in FBCRC and FBWrite commands.

Besides, add "FB: write" command in help info and minor changes for "FB: crc".