### PR TITLE
Fix missing references

### DIFF
--- a/libuuu/libcomm.h
+++ b/libuuu/libcomm.h
@@ -28,6 +28,7 @@
 * POSSIBILITY OF SUCH DAMAGE.
 *
 */
+#include <stdint.h>
 #include <string>
 #include <stdarg.h>
 #include <locale>

--- a/uuu/buildincmd.h
+++ b/uuu/buildincmd.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include <stdint.h>
 #include <map>
 #include <string>
 #include <vector>


### PR DESCRIPTION
I have an error when compiling on Archlinux, the error is as follows:
```
[ 11%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/cmd.cpp.o
[ 14%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/config.cpp.o
[ 17%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/notify.cpp.o
[ 20%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/sdps.cpp.o
[ 23%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/trans.cpp.o
[ 26%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/usbhotplug.cpp.o
[ 29%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/version.cpp.o
[ 32%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/sdp.cpp.o
[ 35%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/fastboot.cpp.o
[ 38%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/zip.cpp.o
[ 41%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/fat.cpp.o
In file included from /home/nixgnauhcuy/.cache/yay/mfgtools/src/uuu-1.5.11/libuuu/fat.cpp:35:
/home/nixgnauhcuy/.cache/yay/mfgtools/src/uuu-1.5.11/libuuu/libcomm.h:88:8: 错误：‘uint64_t’不是一个类型名   88 | inline uint64_t EndianSwap(uint64_t x) {
      |        ^~~~~~~~
/home/nixgnauhcuy/.cache/yay/mfgtools/src/uuu-1.5.11/libuuu/libcomm.h:36:1: 附注：‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   35 | #include <algorithm>
  +++ |+#include <cstdint>
   36 | #pragma once
/home/nixgnauhcuy/.cache/yay/mfgtools/src/uuu-1.5.11/libuuu/libcomm.h:99:8: 错误：‘uint32_t’不是一个类型名   99 | inline uint32_t EndianSwap(uint32_t x)
      |        ^~~~~~~~
/home/nixgnauhcuy/.cache/yay/mfgtools/src/uuu-1.5.11/libuuu/libcomm.h:99:8: 附注：‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/nixgnauhcuy/.cache/yay/mfgtools/src/uuu-1.5.11/libuuu/libcomm.h:106:8: 错误：‘uint16_t’不是一个类型名  106 | inline uint16_t EndianSwap(uint16_t x)
      |        ^~~~~~~~
/home/nixgnauhcuy/.cache/yay/mfgtools/src/uuu-1.5.11/libuuu/libcomm.h:106:8: 附注：‘uint16_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/nixgnauhcuy/.cache/yay/mfgtools/src/uuu-1.5.11/libuuu/libcomm.h:145:1: 错误：‘uint16_t’不是一个类型名  145 | uint16_t str_to_uint16(const string &str, bool * conversion_suceeded = nullptr);
      | ^~~~~~~~
/home/nixgnauhcuy/.cache/yay/mfgtools/src/uuu-1.5.11/libuuu/libcomm.h:145:1: 附注：‘uint16_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/nixgnauhcuy/.cache/yay/mfgtools/src/uuu-1.5.11/libuuu/libcomm.h:146:1: 错误：‘uint32_t’不是一个类型名  146 | uint32_t str_to_uint32(const string &str, bool * conversion_suceeded = nullptr);
      | ^~~~~~~~
/home/nixgnauhcuy/.cache/yay/mfgtools/src/uuu-1.5.11/libuuu/libcomm.h:146:1: 附注：‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/nixgnauhcuy/.cache/yay/mfgtools/src/uuu-1.5.11/libuuu/libcomm.h:147:1: 错误：‘uint64_t’不是一个类型名  147 | uint64_t str_to_uint64(const string &str, bool * conversion_suceeded = nullptr);
      | ^~~~~~~~
/home/nixgnauhcuy/.cache/yay/mfgtools/src/uuu-1.5.11/libuuu/libcomm.h:147:1: 附注：‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
make[2]: *** [libuuu/CMakeFiles/uuc_s.dir/build.make:249：libuuu/CMakeFiles/uuc_s.dir/fat.cpp.o] 错误 1
make[1]: *** [CMakeFiles/Makefile2:116：libuuu/CMakeFiles/uuc_s.dir/all] 错误 2
make: *** [Makefile:136：all] 错误 2
==> 错误： 在 build() 中发生一个错误。    正在放弃...
```

```
make: 进入目录“/home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/build”
[  2%] Generating gitversion.h
build not in appveyor
[  5%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/error.cpp.o
[  8%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/buffer.cpp.o
[ 11%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/cmd.cpp.o
[ 14%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/config.cpp.o
[ 17%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/notify.cpp.o
[ 20%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/sdps.cpp.o
[ 23%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/trans.cpp.o
[ 26%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/usbhotplug.cpp.o
[ 29%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/version.cpp.o
[ 32%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/sdp.cpp.o
[ 35%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/fastboot.cpp.o
[ 38%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/zip.cpp.o
[ 41%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/fat.cpp.o
[ 44%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/tar.cpp.o
[ 47%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/rominfo.cpp.o
[ 50%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/http.cpp.o
[ 52%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/hidreport.cpp.o
[ 55%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/sparse.cpp.o
[ 58%] Linking CXX static library libuuc_s.a
[ 58%] Built target uuc_s
[ 61%] Creating preprocessed clst file /home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/build/uuu/gen/uuu.clst
[ 64%] Creating preprocessed clst file /home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/build/uuu/gen/emmc_burn_all.clst
[ 67%] Creating preprocessed clst file /home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/build/uuu/gen/emmc_burn_loader.clst
[ 70%] Creating preprocessed clst file /home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/build/uuu/gen/fat_write.clst
[ 73%] Creating preprocessed clst file /home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/build/uuu/gen/nand_burn_loader.clst
[ 76%] Creating preprocessed clst file /home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/build/uuu/gen/nvme_burn_all.clst
[ 79%] Creating preprocessed clst file /home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/build/uuu/gen/qspi_burn_loader.clst
[ 82%] Creating preprocessed clst file /home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/build/uuu/gen/sd_burn_all.clst
[ 85%] Creating preprocessed clst file /home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/build/uuu/gen/sd_burn_loader.clst
[ 88%] Creating preprocessed clst file /home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/build/uuu/gen/spl_boot.clst
[ 91%] Building CXX object uuu/CMakeFiles/uuu.dir/uuu.cpp.o
[ 94%] Building CXX object uuu/CMakeFiles/uuu.dir/buildincmd.cpp.o
In file included from /home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/uuu/buildincmd.cpp:32:
/home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/uuu/buildincmd.h:82:17: 错误：‘uint32_t’不是一个类型名   82 |                 uint32_t m_flags = ARG_MUST;
      |                 ^~~~~~~~
/home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/uuu/buildincmd.h:37:1: 附注：‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   36 | #include <vector>
  +++ |+#include <cstdint>
   37 | 
/home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/uuu/buildincmd.cpp: In member function ‘void BuiltInScript::Arg::parser(const std::string&)’:
/home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/uuu/buildincmd.cpp:56:9: 错误：‘m_flags’在此作用域中尚未声明   56 |         m_flags = ARG_OPTION | ARG_OPTION_KEY;
      |         ^~~~~~~
/home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/uuu/buildincmd.cpp: In constructor ‘BuiltInScript::BuiltInScript(const BuiltInScriptRawData*)’:
/home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/uuu/buildincmd.cpp:82:27: 错误：‘class BuiltInScript::Arg’ has no member named ‘m_flags’
   82 |                         a.m_flags = Arg::ARG_MUST;
      |                           ^~~~~~~
/home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/uuu/buildincmd.cpp: In member function ‘std::string BuiltInScript::replace_script_args(const std::vector<std::__cxx11::basic_string<char> >&) const’:
/home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/uuu/buildincmd.cpp:137:31: 错误：‘const __gnu_cxx::__alloc_traits<std::allocator<BuiltInScript::Arg>, BuiltInScript::Arg>::value_type’ {aka ‘const class BuiltInScript::Arg’} has no member named ‘m_flags’
  137 |                 if (m_args[i].m_flags & Arg::ARG_OPTION_KEY)
      |                               ^~~~~~~
/home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/uuu/buildincmd.cpp: In member function ‘void BuiltInScript::show_cmd() const’:
/home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/uuu/buildincmd.cpp:169:31: 错误：‘const __gnu_cxx::__alloc_traits<std::allocator<BuiltInScript::Arg>, BuiltInScript::Arg>::value_type’ {aka ‘const class BuiltInScript::Arg’} has no member named ‘m_flags’
  169 |                 if (m_args[i].m_flags & Arg::ARG_OPTION)
      |                               ^~~~~~~
make[2]: *** [uuu/CMakeFiles/uuu.dir/build.make:140：uuu/CMakeFiles/uuu.dir/buildincmd.cpp.o] 错误 1
make[1]: *** [CMakeFiles/Makefile2:142：uuu/CMakeFiles/uuu.dir/all] 错误 2
make: *** [Makefile:136：all] 错误 2
make: 离开目录“/home/nixgnauhcuy/My/tmp_git/mfgtools-git/src/mfgtools/build”
==> 错误： 在 build() 中发生一个错误。    正在放弃...
```

my archlinux：
```
❯ neofetch                                                                                                                 ─╯
                   -`                    nixgnauhcuy@nixgnauhcuy 
                  .o+`                   ----------------------- 
                 `ooo/                   OS: Arch Linux x86_64 
                `+oooo:                  Host: 82B6 Lenovo Legion R7000 2020 
               `+oooooo:                 Kernel: 6.3.1-arch1-1 
               -+oooooo+:                Uptime: 5 hours, 50 mins 
             `/:-:++oooo+:               Packages: 1030 (pacman) 
            `/++++/+++++++:              Shell: zsh 5.9 
           `/++++++++++++++:             Resolution: 1920x1080, 1920x1080 
          `/+++ooooooooooooo/`           DE: Plasma 5.27.4 
         ./ooosssso++osssssso+`          WM: KWin 
        .oossssso-````/ossssss+`         WM Theme: Breeze 微风 
       -osssssso.      :ssssssso.        Theme: [Plasma], Breeze [GTK2/3] 
      :osssssss/        osssso+++.       Icons: [Plasma], breeze-dark [GTK2/3] 
     /ossssssss/        +ssssooo/-       Terminal: konsole 
   `/ossssso+/:-        -:/+osssso+-     CPU: AMD Ryzen 7 4800H with Radeon Graphics (16) @ 2.900GHz 
  `+sso+:-`                 `.-/+oso:    GPU: NVIDIA 01:00.0 NVIDIA Corporation TU117M 
 `++:.                           `-/+/   GPU: AMD ATI 06:00.0 Renoir 
 .`                                 `/   Memory: 10080MiB / 15360MiB 

```

recurrence path:
``` bash
> yay -S mfgtools-git
```
I added the reference to the header file and it compiles correctly.