### PR TITLE
Qualify call to std::move

### DIFF
--- a/libuuu/usbhotplug.cpp
+++ b/libuuu/usbhotplug.cpp
@@ -141,7 +141,7 @@ static struct {
 	void push_back(string filter)
 	{
 		lock_guard<mutex> guard{lock};
-		list.emplace_back(move(filter));
+		list.emplace_back(std::move(filter));
 	}
 
 	bool is_valid(const string& path)


### PR DESCRIPTION
This fixes a warning reported by clang 14