### PR TITLE
Add virtual destructors to classes with virtual methods

### DIFF
--- a/libuuu/buffer.cpp
+++ b/libuuu/buffer.cpp
@@ -479,7 +479,7 @@ class Bz2stream : public CommonStream
 
 public:
 	Bz2stream() { memset(&m_strm, 0, sizeof(m_strm));  BZ2_bzDecompressInit(&m_strm, 0, 0); }
-	~Bz2stream()
+	virtual ~Bz2stream()
 	{
 		BZ2_bzDecompressEnd(&m_strm);
 	}
@@ -533,7 +533,7 @@ public:
 		memset(&m_strm, 0, sizeof(m_strm));
 		inflateInit2(&m_strm, 15 + 16);
 	}
-	~Gzstream()
+	virtual ~Gzstream()
 	{
 		deflateEnd(&m_strm);
 	}
@@ -631,7 +631,7 @@ public:
 	{
 		m_dctx = ZSTD_createDCtx();
 	};
-	~ZstdStream()
+	virtual ~ZstdStream()
 	{
 		ZSTD_freeDCtx(m_dctx);
 	}
@@ -934,6 +934,7 @@ int FSCompressStream::for_each_ls(uuu_ls_file fn, const string &backfile, const 
 class Bz2FragmentBlock: public FragmentBlock
 {
 public:
+	virtual ~Bz2FragmentBlock() {}
 	int DataConvert() override
 	{
 		std::lock_guard<mutex> lock(m_mutex);

--- a/libuuu/buffer.h
+++ b/libuuu/buffer.h
@@ -102,6 +102,8 @@ public:
 			return m_pData;
 		return m_data.data();
 	}
+
+	virtual ~FragmentBlock() {}
 };
 
 
@@ -148,7 +150,7 @@ public:
 	{
 		return (*this)[index];
 	}
-	~DataBuffer()
+	virtual ~DataBuffer()
 	{
 		if (m_allocate_way == ALLOCATION_WAYS::MALLOC)
 		{


### PR DESCRIPTION
This fixes a number of warnings reported by clang 14:

    warning: delete called on non-final 'FragmentBlock' that has virtual
    functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]