### PR TITLE
Remove unused variables

### DIFF
--- a/libuuu/buffer.cpp
+++ b/libuuu/buffer.cpp
@@ -1430,8 +1430,6 @@ void FileBuffer::truncate_old_data_in_pool()
 
 	size_t off = m_last_request_offset - m_totall_buffer_size/2;
 
-	size_t free_sz = 0;
-
 	for (auto it= m_seg_map.lower_bound(off); it != m_seg_map.end(); it++)
 	{
 		auto blk = it->second;
@@ -1444,7 +1442,6 @@ void FileBuffer::truncate_old_data_in_pool()
 			blk->m_dataflags = 0;
 			blk->m_actual_size = 0;
 			vector<uint8_t> v;
-			free_sz += blk->m_data.size();
 			blk->m_data.swap(v);
 		}
 	}

--- a/libuuu/zip.h
+++ b/libuuu/zip.h
@@ -172,7 +172,6 @@ private:
 	size_t m_compressedsize;
 	size_t m_offset;
 	z_stream m_strm;
-	bool m_decompressed;
 
 	friend Zip;
 };


### PR DESCRIPTION
Both gcc and clang emit warnings on the two removed variables.