### PR TITLE
Update Readme: missing Linux dependency and use `git clone --recurse-submodules` to get submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Note that, since uuu is an OSI compliant Open Source project, you are entitled t
 ## Linux
 - `git clone https://github.com/nxp-imx/mfgtools.git`
 - `cd mfgtools`
-- `sudo apt-get install libusb-1.0-0-dev libbz2-dev libzstd-dev pkg-config cmake libssl-dev g++`
+- `sudo apt-get install libusb-1.0-0-dev libbz2-dev libzstd-dev pkg-config cmake libssl-dev g++ zlib1g-dev`
 - `cmake . && make`
 
 The above commands build mfgtools in source. To build it out of source

--- a/README.md
+++ b/README.md
@@ -59,10 +59,8 @@ The prebuilt image and document are here:
 # How to Build:
 
 ## Windows
-- `git clone https://github.com/nxp-imx/mfgtools.git`
+- `git clone --recurse-submodules https://github.com/nxp-imx/mfgtools.git`
 - `cd mfgtools`
-- `git submodule init`
-- `git submodule update`
 - `open msvs/uuu.sln with Visual Studio 2017`
 
 Visual Studio


### PR DESCRIPTION
Add missing Linux dependency `zlib1g-dev` and use `git clone --recurse-submodules` to get `git submodule`