### PR TITLE
Fix write size for Windows

### DIFF
--- a/libuuu/hidreport.cpp
+++ b/libuuu/hidreport.cpp
@@ -78,7 +78,14 @@ int HIDReport::write(const void *p, size_t sz, uint8_t report_id)
 		m_out_buff[0] = report_id;
 
 		size_t s = sz - off;
-		if (s > m_size_out)
+
+		/*
+		 * The Windows HIDAPI is ver strict. It always require to send
+		 * buffers of the size reported by the HID Report Descriptor.
+		 * Therefore we must to send m_size_out buffers for HID ID 2
+		 * albeit it may not required for the last buffer.
+		 */
+		if (s > m_size_out || report_id == 2)
 			s = m_size_out;
 
 		memcpy(m_out_buff.data() + m_size_payload, buff + off, s);


### PR DESCRIPTION
With commit 96aae2eaaca9 ("libuuu: hidreport: fix write size")I  introduced an regression for Windows hosts. The Windows HIDAPI is very strict when it comes to packet lengths: The API always expect the length specified by the device and rejects the transfer otherwise.

Can we please test this PR via CI, so I can verify that the uuu.exe does work again on Windows? If verified we can merge it there are no objections.