### PR TITLE
libuuu: sdps: add support for uploading i.MX8MP/N barebox binaries

### DIFF
--- a/libuuu/sdps.cpp
+++ b/libuuu/sdps.cpp
@@ -81,6 +81,18 @@ struct _ST_HID_CBW
 
 #include "rominfo.h"
 
+static bool is_ivt_barker_header(shared_ptr<DataBuffer> data, size_t off)
+{
+	if (off + sizeof(IvtHeader) > data->size())
+		return false;
+
+	IvtHeader *p = (IvtHeader*)(data->data() + off);
+	if (p->IvtBarker == IVT_BARKER_HEADER || p->IvtBarker == IVT_BARKER2_HEADER)
+		return true;
+
+	return false;
+}
+
 int SDPSCmd::run(CmdCtx *pro)
 {
 	const ROM_INFO * rom = search_rom_info(pro->m_config_item);
@@ -144,6 +156,11 @@ int SDPSCmd::run(CmdCtx *pro)
 
 	if (m_bskipflashheader)
 		offset += GetFlashHeaderSize(p, offset);
+
+	// Detect barebox binaries that have the IVT header at offset 32K
+	if (!is_ivt_barker_header(p, offset) &&
+	     is_ivt_barker_header(p, offset + 0x8000))
+		offset += 0x8000;
 
 	if (offset >= p->size())
 	{


### PR DESCRIPTION
uuu can already upload preprocessed barebox binaries on the i.MX8M Nano and Plus, because barebox uses the BootROM's API to chainload barebox proper on these platforms.

The preprocessing that needs to happen is the removal of the first 32K of the barebox image, which allows barebox to be flashed directly to the start of an SD-Card or the eMMC user area.

Improve user experience by transparently removing the first 32K of images if the image has no IVT magic at offset 0, but an IVT magic at offset 0x8000.

This should ensure that existing upload of U-Boot images works as before, while allowing upload of barebox images for Nano and Plus as well.

This change has been verified by uploading both a barebox and an U-Boot binary on an i.MX8MN.