### PR TITLE
SDP Barebox Autodetection

### DIFF
--- a/libuuu/sdp.h
+++ b/libuuu/sdp.h
@@ -213,6 +213,7 @@ public:
 	int run(CmdCtx *p) override;
 
 private:
+	bool is_barebox_img(void);
 	int load_barebox(CmdCtx *ctx);
 
 	bool m_clear_dcd = false;


### PR DESCRIPTION
We do already support the -barebox switch, so the user can force the barebox image handling. Add a autodetection mechanism to make it even more user friendly. The autodetection is based on the fact, that barebox does add an "barebox" string at offset 0x20 to the image. If this string is found we can assume that user provided file is an barebox image.