### PR TITLE
fix: integer overflow causing segmentation fault

### DIFF
--- a/libuuu/buffer.cpp
+++ b/libuuu/buffer.cpp
@@ -1709,7 +1709,7 @@ std::shared_ptr<DataBuffer> FileBuffer::request_data(size_t offset, size_t sz)
 			return p;
 	}
 
-	if (sz == UINT64_MAX)
+	if (sz == SIZE_MAX)
 		sz = size() - offset;
 
 	p->resize(sz);

--- a/libuuu/fastboot.cpp
+++ b/libuuu/fastboot.cpp
@@ -249,7 +249,7 @@ int FBDownload::run(CmdCtx *ctx)
 	if (buff == nullptr)
 		return -1;
 
-	shared_ptr<DataBuffer> pdata = buff->request_data(0, UINT64_MAX);
+	shared_ptr<DataBuffer> pdata = buff->request_data(0, SIZE_MAX);
 	if (!pdata)
 		return -1;
 	string_ex cmd;
@@ -367,7 +367,7 @@ int FBCopy::run(CmdCtx *ctx)
 		{
 			return -1;
 		}
-		shared_ptr<DataBuffer> buff = pin->request_data(0, UINT64_MAX);
+		shared_ptr<DataBuffer> buff = pin->request_data(0, SIZE_MAX);
 		if (!buff)
 			return -1;
 		cmd.format("WOpen:%s", m_target_file.c_str());

--- a/libuuu/sdps.cpp
+++ b/libuuu/sdps.cpp
@@ -150,7 +150,7 @@ int SDPSCmd::run(CmdCtx *pro)
 	}
 	else
 	{
-		p = p1->request_data(0, UINT64_MAX); //request all data
+		p = p1->request_data(0, SIZE_MAX); //request all data
 		if (!p) return -1;
 	}
 


### PR DESCRIPTION
This fixes a segmentation fault when trying to flash images from any `armv7` host. uuu compares a size_t to `UINT64_MAX` which is obviously never true on 32-bit architectures. When calling the faulty with `UNIT64_MAX`, the size_t overflows. This PR fixes this by comparing to correct variable `SIZE_MAX` instead.