### PR TITLE
libuuu: do not crash when using FB: write -format without @off or @size

### DIFF
--- a/libuuu/fastboot.cpp
+++ b/libuuu/fastboot.cpp
@@ -1024,14 +1024,18 @@ string FBLoop::build_cmd(string& cmd, size_t off, size_t sz)
 	ucmd += cmd;
 
 	string_ex ex;
-	ex.format("0x%llx", off);
 
 	size_t pos= ucmd.find("@off");
-	ucmd = ucmd.replace(pos, 4, ex);
+	if (pos != string::npos) {
+		ex.format("0x%llx", off);
+		ucmd = ucmd.replace(pos, 4, ex);
+	}
 
-	ex.format("0x%llx", sz);
 	pos = ucmd.find("@size");
-	ucmd = ucmd.replace(pos, 5, ex);
+	if (pos != string::npos) {
+		ex.format("0x%llx", sz);
+		ucmd = ucmd.replace(pos, 5, ex);
+	}
 
 	return ucmd;
 }


### PR DESCRIPTION
Check the return code of ucmd.find(), so we don't attempt to replace with an out-of-bounds index when the command string does not contain the `@off` and `@size` patterns.