### PR TITLE
Change udev rules back to MODE="0664" instead of uaccess.

### DIFF
--- a/uuu/uuu.cpp
+++ b/uuu/uuu.cpp
@@ -258,7 +258,7 @@ int print_cfg(const char *pro, const char * chip, const char * /*compatible*/, u
 int print_udev_rule(const char * /*pro*/, const char * /*chip*/, const char * /*compatible*/,
 	uint16_t vid, uint16_t pid, uint16_t /*bcdmin*/, uint16_t /*bcdmax*/, void * /*p*/)
 {
-	printf("SUBSYSTEM==\"usb\", ATTRS{idVendor}==\"%04x\", ATTRS{idProduct}==\"%04x\", TAG+=\"uaccess\"\n",
+	printf("SUBSYSTEM==\"usb\", ATTRS{idVendor}==\"%04x\", ATTRS{idProduct}==\"%04x\", MODE=\"0664\"\n",
 			vid, pid);
 	return 0;
 }


### PR DESCRIPTION
When you e.g. have a service that flashes your modules it might run as a dedicated user, which is unable to login. In this case uaccess does not work.

BTW, it might be useful to also add `GROUP="plugdev"` or something similar to the udev rules.
Also, I stripped my udev rules down to some leaner version relying on vendor-id.

e.g.:

```
SUBSYSTEM=="usb", ATTRS{idVendor}=="1fc9", MODE="0664", GROUP="plugdev"
SUBSYSTEM=="usb", ATTRS{idVendor}=="15a2", MODE="0664", GROUP="plugdev"
SUBSYSTEM=="usb", ATTRS{idVendor}=="0525", MODE="0664", GROUP="plugdev"
SUBSYSTEM=="usb", ATTRS{idVendor}=="3016", MODE="0664", GROUP="plugdev"
SUBSYSTEM=="usb", ATTRS{idVendor}=="066f", MODE="0664", GROUP="plugdev"
SUBSYSTEM=="usb", ATTRS{idVendor}=="18d1", MODE="0664", GROUP="plugdev"
SUBSYSTEM=="usb", ATTRS{idVendor}=="3016", MODE="0664", GROUP="plugdev"
SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", MODE="0664", GROUP="plugdev"
```