### PR TITLE
Don't download the FCB copy image for SDPS

### DIFF
--- a/libuuu/rominfo.cpp
+++ b/libuuu/rominfo.cpp
@@ -120,12 +120,13 @@ struct rom_bootimg {
 };
 
 
+static constexpr uint32_t IMG_FCB_COPY = 0x08;
 static constexpr uint32_t IMG_V2X = 0x0B;
 
 #pragma pack ()
 
 
-size_t GetContainerActualSize(shared_ptr<DataBuffer> p, size_t offset, bool bROMAPI)
+size_t GetContainerActualSize(shared_ptr<DataBuffer> p, size_t offset, bool bROMAPI, bool skipspl)
 {
 	if(bROMAPI)
 		return p->size() - offset;
@@ -154,6 +155,12 @@ size_t GetContainerActualSize(shared_ptr<DataBuffer> p, size_t offset, bool bROM
 	image = reinterpret_cast<struct rom_bootimg *>(p->data() + offset + cindex * CONTAINER_HDR_ALIGNMENT
 		+ sizeof(struct rom_container)
 		+ sizeof(struct rom_bootimg) * (hdr->num_images - 1));
+
+	/* Check if the image is FCB copy */
+	if (((image->flags & 0xF) == IMG_FCB_COPY) && !skipspl)
+	{
+		image--;
+	}
 
 	uint32_t sz = image->size + image->offset + cindex * CONTAINER_HDR_ALIGNMENT;
 

--- a/libuuu/rominfo.h
+++ b/libuuu/rominfo.h
@@ -68,6 +68,6 @@ struct ROM_INFO
 const ROM_INFO * search_rom_info(const std::string &s);
 const ROM_INFO * search_rom_info(const ConfigItem *item);
 
-size_t GetContainerActualSize(std::shared_ptr<DataBuffer> p, size_t offset, bool bROMAPI=false);
+size_t GetContainerActualSize(std::shared_ptr<DataBuffer> p, size_t offset, bool bROMAPI=false, bool skipspl=false);
 size_t GetFlashHeaderSize(std::shared_ptr<DataBuffer> p, size_t offset = 0);
 

--- a/libuuu/sdp.cpp
+++ b/libuuu/sdp.cpp
@@ -490,7 +490,7 @@ int SDPWriteCmd::run(CmdCtx*ctx)
 			}
 			else
 			{
-				offset += GetContainerActualSize(fbuff, offset);
+				offset += GetContainerActualSize(fbuff, offset, rom->flags & ROM_INFO_HID_ROMAPI, m_bskipspl);
 			}
 
 			if (size_t(offset) >= fbuff->size())


### PR DESCRIPTION
ROM doesn't need the FCB copy image for the SDPS, remove it to avoid USB report error.