### PR TITLE
include missing stdint.h

### DIFF
--- a/libuuu/libcomm.h
+++ b/libuuu/libcomm.h
@@ -28,7 +28,7 @@
 * POSSIBILITY OF SUCH DAMAGE.
 *
 */
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <stdarg.h>
 #include <locale>

--- a/uuu/buildincmd.h
+++ b/uuu/buildincmd.h
@@ -31,7 +31,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>


### PR DESCRIPTION
This fixes build latest gcc-14

Fixes build errors below

/mnt/b/yoe/master/build/tmp/work/x86_64-nativesdk-yoesdk-linux/nativesdk-uuu/1.5.21/git/libuuu/libcomm.h:106:8: error: 'uint16_t' does not name a type
  106 | inline uint16_t EndianSwap(uint16_t x)
      |        ^~~~~~~~
/mnt/b/yoe/master/build/tmp/work/x86_64-nativesdk-yoesdk-linux/nativesdk-uuu/1.5.21/git/libuuu/libcomm.h:106:8: note: 'uint16_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'