### PR TITLE
Bugfix against SegFault of #420: If info is 0, no access on content is possible.

### DIFF
--- a/libuuu/usbhotplug.cpp
+++ b/libuuu/usbhotplug.cpp
@@ -247,7 +247,8 @@ static string get_device_serial_no(libusb_device *dev, struct libusb_device_desc
 
 	if (!sid) {
 		const ROM_INFO *info= search_rom_info(item);
-		sid = info->serial_idx;
+		if (info)
+			sid = info->serial_idx;
 	}
 
 	serial.resize(SERIAL_NO_MAX);


### PR DESCRIPTION
Bugfix against SegFault of https://github.com/nxp-imx/mfgtools/issues/420: If info is 0, no access on content is possible.