### PR TITLE
Fix if-command comparison code

### DIFF
--- a/libuuu/cmd.cpp
+++ b/libuuu/cmd.cpp
@@ -885,10 +885,10 @@ int CmdIf::run(CmdCtx *p)
 	build_map(p);
 
 	if (is_env_exist(l))
-		l = get_env_variable(l);
+		l = str_to_upper(get_env_variable(l));
 
 	if (is_env_exist(r))
-		r = get_env_variable(r);
+		r = str_to_upper(get_env_variable(r));
 
 	switch (i)
 	{


### PR DESCRIPTION
To avoid case-sensitivity problems, uppercase
both sides of a comparison after variable substitutions.