### PR TITLE
Fix and rename `Config::find` to `Config::filter`

### DIFF
--- a/libuuu/config.cpp
+++ b/libuuu/config.cpp
@@ -121,17 +121,6 @@ ConfigItem * Config::find(uint16_t vid, uint16_t pid, uint16_t ver)
 	return nullptr;
 }
 
-Config Config::find(const string &pro)
-{
-	Config items;
-	for (auto it = begin(); it != end(); it++)
-	{
-		if (it->m_protocol == pro)
-			items.emplace_back(*it);
-	}
-	return items;
-}
-
 int CfgCmd::run(CmdCtx *)
 {
 	size_t pos = 0;

--- a/libuuu/config.h
+++ b/libuuu/config.h
@@ -63,7 +63,6 @@ class Config :public std::vector<ConfigItem>
 public:
 	Config();
 	ConfigItem *find(uint16_t vid, uint16_t pid, uint16_t ver);
-	Config find(const std::string &protocol);
 };
 
 Config * get_config() noexcept;


### PR DESCRIPTION
I always scratched my head looking at `Config Config::find(const string &pro)`, wondering about its purpose. If I don't misinterpret it it creates a new instance of `Config` - holding all default `ConfigItem`s and then adds the ones of the current instance additionally which fit the passed protocol.

Since I guess it should rather _filter_ I modified the `Config` constructor to allow creating an instance without any `ConfigItem`s and then adding just selected ones within the `filter` function.