### PR TITLE
Fix faulty return values of `load_bmap` function

### DIFF
--- a/libuuu/bmap.cpp
+++ b/libuuu/bmap.cpp
@@ -118,7 +118,7 @@ void send_info(std::string msg)
 	call_notify(nt);
 }
 
-bool load_bmap(const std::string& filename, bmap_t& bmap)
+int load_bmap(const std::string& filename, bmap_t& bmap)
 {
 	tinyxml2::XMLDocument doc;
 	auto fbuf = get_file_buffer(filename, true);

--- a/libuuu/bmap.h
+++ b/libuuu/bmap.h
@@ -62,4 +62,4 @@ private:
 	mutable size_t m_next_gap_begin = 0;
 };
 
-bool load_bmap(const std::string& filename, bmap_t& bmap);
+int load_bmap(const std::string& filename, bmap_t& bmap);

--- a/libuuu/fastboot.cpp
+++ b/libuuu/fastboot.cpp
@@ -727,7 +727,7 @@ int FBFlashCmd::run(CmdCtx *ctx)
 
 			m_bmap = bmap_t{SIZE_MAX, block_size};
 		// load mappings from the file
-		} else if (!load_bmap(m_bmap_filename, m_bmap)) {
+		} else if (load_bmap(m_bmap_filename, m_bmap)) {
 			set_last_err_string("Failed to load BMAP");
 			return -1;
 		}


### PR DESCRIPTION
This is just a tiny pull request. The `load_bmap` function returns a `bool` value. The returned `-1` values would be converted to `true` (since they are non-zero) which would signal success faultily.