### PR TITLE
Change the return type of `load_bmap` to an integer, as well as change it to 0

### DIFF
--- a/libuuu/bmap.cpp
+++ b/libuuu/bmap.cpp
@@ -174,5 +174,5 @@ int load_bmap(const std::string& filename, bmap_t& bmap)
 		send_info(info + "\n");
 	}
 
-	return true;
+	return 0;
 }


### PR DESCRIPTION
Changes the return type of `load_bmap` to an integer, as well as change it to 0 thus indicating a successful bmap load.

closes #456 