### PR TITLE
fix: memory corruption in libuuu fastboot

### DIFF
--- a/libuuu/fastboot.cpp
+++ b/libuuu/fastboot.cpp
@@ -66,6 +66,8 @@ int FastBoot::Transport(string cmd, void *p, size_t size, vector<uint8_t> *input
 		memset(buff, 0, 65);
 		if (m_pTrans->read(buff, 64, &actual))
 			return -1;
+	
+		buff[actual] = '\0';
 
 		if (strncmp(buff, "DATA",4) == 0)
 		{

--- a/wrapper/CMakePresets.json
+++ b/wrapper/CMakePresets.json
@@ -15,7 +15,8 @@
       "generator": "Visual Studio 17 2022",
       "inherits": [ "default" ],
       "cacheVariables": {
-        "VCPKG_TARGET_TRIPLET": "x64-windows-sd"
+        "VCPKG_TARGET_TRIPLET": "x64-windows-sd",
+        "CMAKE_CXX_VERSION": "19.42"
       }
     },
     {

--- a/wrapper/pyproject.toml
+++ b/wrapper/pyproject.toml
@@ -53,6 +53,7 @@ target-version = ["py39", "py310", "py311"]
 include = '\.pyi?$'
 
 [tool.isort]
+skip = ["__version__.py"]
 multi_line_output = 3
 include_trailing_comma = true
 force_grid_wrap = 0

--- a/wrapper/requirements.txt
+++ b/wrapper/requirements.txt
@@ -1,1 +1,1 @@
-setuptools-scm>=8
+setuptools-scm<8.2


### PR DESCRIPTION
This PR addresses the issue of memory corruption observed when using the Python binding for libuuu on Mac OS X Apple Silicon. The problem was identified in the `FastBoot::Transport` method, where the response buffer was not properly null-terminated.

### Changes Made:
1. **Null-Termination**: Added a line to ensure that the response buffer is null-terminated after reading data from the transport layer.
2. **Updated Dependencies & Configuration**: Adjusted dependency pinning for `setuptools_scm` and added automatedly generated `__version__.py` file into ignore list for `isort` tool

### Testing:
The fix was tested on Mac OS X Apple Silicon, Ubuntu and Windows 11, confirming that the issue is resolved on macOS while maintaining functionality on other platforms.

### References:
- Issue: [#438](https://github.com/nxp-imx/mfgtools/issues/438)