### PR TITLE
libuuu/sdps: fix gcc15 compile errors

### DIFF
--- a/libuuu/sdps.h
+++ b/libuuu/sdps.h
@@ -30,6 +30,7 @@
 */
 
 #include "cmd.h"
+#include <cstdint>
 
 class SDPSCmd : public CmdBase
 {


### PR DESCRIPTION
This gcc 15 error happens on Fedora 42.

error: uint32_t does not name a type

error: uint64_t does not name a type