### PR TITLE
libuuu: Fix typo & compilation warning in error message

### DIFF
--- a/libuuu/buffer.cpp
+++ b/libuuu/buffer.cpp
@@ -1347,7 +1347,7 @@ int FileBuffer::mapfile(const string &filename, size_t sz)
 		{
 			string err;
 			err += "xx Failure open file: ";
-			err + filename;
+			err += filename;
 			set_last_err_string(err);
 			return -1;
 		}


### PR DESCRIPTION
The previous code generating the following warning:

```
[  8%] Building CXX object libuuu/CMakeFiles/uuc_s.dir/buffer.cpp.o
/tmp/buildd/github/mfgtools/libuuu/buffer.cpp: In member function 'int FileBuffer::mapfile(const std::string&, size_t)':
/tmp/buildd/github/mfgtools/libuuu/buffer.cpp:1350:31: warning: ignoring return value of 'std::__cxx11::basic_string<_CharT, _Traits, _Alloc> std::operator+(const __cxx11::basic_string<_CharT, _Traits, _Alloc>&, const __cxx11::basic_string<_CharT, _Traits, _Alloc>&) [with _CharT = char; _Traits = char_traits<char>; _Alloc = allocator<char>]', declared with attribute 'nodiscard' [-Wunused-result]
 1350 |                         err + filename;
      |                               ^~~~~~~~
In file included from /usr/include/c++/15/string:56,
                 from /tmp/buildd/github/mfgtools/libuuu/liberror.h:34,
                 from /tmp/buildd/github/mfgtools/libuuu/buffer.h:43,
                 from /tmp/buildd/github/mfgtools/libuuu/buffer.cpp:33:
/usr/include/c++/15/bits/basic_string.h:3626:5: note: declared here
 3626 |     operator+(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
      |     ^~~~~~~~
```

It seems `err + filename;` is obviously a typo where filename was supposed to be appended to the error string, similar to other places in the same file.