### PR TITLE
support burn large image into flash

### DIFF
--- a/libuuu/fastboot.cpp
+++ b/libuuu/fastboot.cpp
@@ -1082,19 +1082,28 @@ string FBLoop::build_cmd(string& cmd, size_t off, size_t sz)
 {
 	string ucmd="UCmd: ";
 	ucmd += cmd;
+	size_t pos;
 
 	string_ex ex;
 
-	size_t pos= ucmd.find("@off");
-	if (pos != string::npos) {
-		ex.format("0x%llx", off);
-		ucmd = ucmd.replace(pos, 4, ex);
+	while(1) {
+		pos= ucmd.find("@off");
+		if (pos != string::npos) {
+			ex.format("0x%llx", off);
+			ucmd = ucmd.replace(pos, 4, ex);
+		} else {
+			break;
+		}
 	}
 
-	pos = ucmd.find("@size");
-	if (pos != string::npos) {
-		ex.format("0x%llx", sz);
-		ucmd = ucmd.replace(pos, 5, ex);
+	while (1) {
+		pos = ucmd.find("@size");
+		if (pos != string::npos) {
+			ex.format("0x%llx", sz);
+			ucmd = ucmd.replace(pos, 5, ex);
+		} else {
+			break;
+		}
 	}
 
 	return ucmd;

--- a/uuu/qspi_burn_loader.lst
+++ b/uuu/qspi_burn_loader.lst
@@ -33,11 +33,16 @@ FB: ucmd if test ! -n "$fastboot_bytes"; then setenv fastboot_bytes $filesize; e
 
 # Check Image if include flexspi header
 FB: ucmd if qspihdr dump ${fastboot_buffer}; then setenv qspihdr_exist yes; else setenv qspihdr_exist no; fi;
+# Check Image size if larger than 16M, then use uboot command to write image
+FB: ucmd if itest ${fastboot_buffer} -gt 1000000; then setenv qspihdr_large yes; else setenv qspihdr_large no; fi;
 
-FB[-t 60000]: ucmd if test ${qspihdr_exist} = yes; then qspihdr init ${fastboot_buffer} ${fastboot_bytes} safe; else true; fi;
+FB[-t 60000]: ucmd if test ${qspihdr_exist} = yes -a ${qspihdr_large} = no; then qspihdr init ${fastboot_buffer} ${fastboot_bytes} safe; else true; fi;
 
 #if uboot can't support qspihdr command, use uboot image to write qspi image, which require image include qspi flash header
 FB: ucmd if test ${qspihdr_exist} = no; then sf probe; else true; fi;
 FB[-t 40000]: ucmd if test ${qspihdr_exist} = no; then sf erase 0 +${fastboot_bytes}; else true; fi;
 FB[-t 20000]: ucmd if test ${qspihdr_exist} = no; then sf write ${fastboot_buffer} 0 ${fastboot_bytes}; else true; fi;
+# if Image is larger than 16M, use uboot command to write image
+FB: ucmd if test ${qspihdr_large} = yes; then sf probe; else true; fi;
+FB: write -f _image -format "sf erase @off +@size; sf write ${fastboot_buffer} @off @size" -blksz 1 -each 0x100000
 FB: done


### PR DESCRIPTION
Modified the qspi script and uuu source code to support burn large images.  Splitting the large image into small chunks to avoid uuu timeout.