### PR TITLE
Unregister notify_done when uuu_wait_uuu_finish returns

### DIFF
--- a/libuuu/cmd.cpp
+++ b/libuuu/cmd.cpp
@@ -1178,9 +1178,12 @@ int uuu_wait_uuu_finish(int deamon, int dry)
 	if (!deamon)
 		uuu_register_notify_callback(notify_done, &exit);
 
-	if(polling_usb(exit))
+	if (polling_usb(exit)) {
+		uuu_unregister_notify_callback(notify_done);
 		return -1;
+	}
 
+	uuu_unregister_notify_callback(notify_done);
 	clean_up_filemap();
 	return 0;
 }


### PR DESCRIPTION
When `uuu_wait_uuu_finish` method returns, the notify callback should be unregistered. Otherwise, repeated call to the function will cause a crash because the reference to `std::atomic<int> exit` won't be valid anymore.